### PR TITLE
Remove redundant await use

### DIFF
--- a/src/modules/reducer.js
+++ b/src/modules/reducer.js
@@ -51,7 +51,7 @@ export function loadQuestions() {
   return async (dispatch) => {
     const questions = await fetchQuestions();
 
-    await dispatch(clearInterviewQuestions());
-    await dispatch(setInterviewQuestions(questions));
+    dispatch(clearInterviewQuestions());
+    dispatch(setInterviewQuestions(questions));
   };
 }


### PR DESCRIPTION
Remove redundant await use because action is not returns Promise object.